### PR TITLE
Add installation instructions for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ After selecting process you can kill it with Ctrl + X
 
 **[Archives of precompiled binaries for pik are available for Linux and macOS.](https://github.com/jacek-kurlit/pik/releases)**
 
+On **Arch Linux**
+
+```sh
+pacman -S pik
+```
+
 On **Fedora**
 
 ```sh


### PR DESCRIPTION
Now available for Arch Linux: <https://archlinux.org/packages/extra/x86_64/pik/> 🥳
