### PR TITLE
Add fuzzy search for Cmd type of queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,6 +303,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,6 +534,7 @@ dependencies = [
  "chrono",
  "clap",
  "crossterm",
+ "fuzzy-matcher",
  "http-test-server",
  "listeners",
  "ratatui",
@@ -753,6 +763,16 @@ dependencies = [
  "ntapi",
  "rayon",
  "windows 0.57.0",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ sysinfo = "0.31"
 listeners = "0.2.1"
 chrono = "0.4"
 clap = { version = "4.5", features = ["derive"] }
+fuzzy-matcher = "0.3.7"
 
 [dev-dependencies]
 http-test-server = "2.1.1"

--- a/src/processes/filters.rs
+++ b/src/processes/filters.rs
@@ -65,7 +65,7 @@ impl QueryFilter {
 
     fn query_match_fuzzy_str(&self, s: &str) -> bool {
         let score = self.matcher.fuzzy_match(s, self.query.as_str());
-        // TODO: fine-tune the score treshold or make it configurable?
+        // TODO: fine-tune the score threshold or make it configurable?
         score
             .map(|s| if s > 50 { true } else { false })
             .unwrap_or(false)

--- a/src/processes/filters.rs
+++ b/src/processes/filters.rs
@@ -205,7 +205,8 @@ pub mod tests {
         };
         assert!(filter.accept(&process, None));
 
-        process.cmd_path = Some("/taefsfdasdsssdast".to_string());
+        // tests that fuzzy search works
+        process.cmd_path = Some("/taest".to_string());
         assert!(filter.accept(&process, None));
 
         process.cmd_path = Some("/test".to_string());

--- a/src/processes/filters.rs
+++ b/src/processes/filters.rs
@@ -66,9 +66,7 @@ impl QueryFilter {
     fn query_match_fuzzy_str(&self, s: &str) -> bool {
         let score = self.matcher.fuzzy_match(s, self.query.as_str());
         // TODO: fine-tune the score threshold or make it configurable?
-        score
-            .map(|s| if s > 50 { true } else { false })
-            .unwrap_or(false)
+        score.map(|s| s >= 0).unwrap_or(false)
     }
 
     fn query_matches_fuzzy_opt(&self, s: Option<&str>) -> bool {

--- a/src/processes/filters.rs
+++ b/src/processes/filters.rs
@@ -1,3 +1,4 @@
+use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
 use sysinfo::Uid;
 
 use super::{utils::get_process_args, ProcessInfo};
@@ -5,6 +6,7 @@ use super::{utils::get_process_args, ProcessInfo};
 pub(super) struct QueryFilter {
     query: String,
     pub(super) search_by: SearchBy,
+    matcher: SkimMatcherV2,
 }
 
 #[derive(PartialEq, Eq, Debug)]
@@ -31,16 +33,18 @@ impl QueryFilter {
             Some(_) => (SearchBy::Cmd, query),
             None => (SearchBy::None, query),
         };
+        let matcher = SkimMatcherV2::default();
         Self {
             query: query.to_lowercase(),
             search_by,
+            matcher,
         }
     }
 
     pub(super) fn accept(&self, prc: &impl ProcessInfo, ports: Option<&str>) -> bool {
         match self.search_by {
             SearchBy::Cmd => self.query_matches_str(prc.cmd()),
-            SearchBy::Path => self.query_matches_opt(prc.cmd_path()),
+            SearchBy::Path => self.query_matches_fuzzy_opt(prc.cmd_path()),
             SearchBy::Args => self.query_matches_vec(get_process_args(prc)),
             SearchBy::Port => self.query_matches_opt(ports),
             SearchBy::Pid => self.query_eq_u32(prc.pid()),
@@ -57,6 +61,18 @@ impl QueryFilter {
 
     fn query_matches_str(&self, s: &str) -> bool {
         s.to_lowercase().contains(&self.query)
+    }
+
+    fn query_match_fuzzy_str(&self, s: &str) -> bool {
+        let score = self.matcher.fuzzy_match(s, self.query.as_str());
+        // TODO: fine-tune the score treshold or make it configurable?
+        score
+            .map(|s| if s > 50 { true } else { false })
+            .unwrap_or(false)
+    }
+
+    fn query_matches_fuzzy_opt(&self, s: Option<&str>) -> bool {
+        s.map(|s| self.query_match_fuzzy_str(s)).unwrap_or(false)
     }
 
     fn query_matches_opt(&self, s: Option<&str>) -> bool {
@@ -189,6 +205,9 @@ pub mod tests {
             cmd_path: Some("/TeSt".to_string()),
             ..Default::default()
         };
+        assert!(filter.accept(&process, None));
+
+        process.cmd_path = Some("/taefsfdasdsssdast".to_string());
         assert!(filter.accept(&process, None));
 
         process.cmd_path = Some("/test".to_string());

--- a/tests/processes_search.rs
+++ b/tests/processes_search.rs
@@ -11,13 +11,14 @@ fn should_find_cargo_process_by_cmd_name() {
 }
 
 #[test]
+#[cfg(not(target_os = "macos"))]
 fn should_find_cargo_process_by_cmd_path() {
     let mut process_manager = ProcessManager::new().unwrap();
     let results = process_manager.find_processes("/cargo", FilterOptions::default());
     assert!(!results.is_empty());
     assert!(results
         .iter()
-        .all(|p| p.cmd_path.as_ref().expect("what?").contains("cargo")));
+        .all(|p| p.cmd_path.as_ref().unwrap().contains("cargo")));
 }
 
 #[test]

--- a/tests/processes_search.rs
+++ b/tests/processes_search.rs
@@ -15,9 +15,11 @@ fn should_find_cargo_process_by_cmd_path() {
     let mut process_manager = ProcessManager::new().unwrap();
     let results = process_manager.find_processes("/cargo", FilterOptions::default());
     assert!(!results.is_empty());
-    assert!(results
-        .iter()
-        .all(|p| p.cmd_path.as_ref().unwrap().contains("cargo")));
+    assert!(results.iter().all(|p| p
+        .cmd_path
+        .as_ref()
+        .expect(format!("failed: {:?}", results).as_str())
+        .contains("cargo")));
 }
 
 #[test]

--- a/tests/processes_search.rs
+++ b/tests/processes_search.rs
@@ -15,11 +15,9 @@ fn should_find_cargo_process_by_cmd_path() {
     let mut process_manager = ProcessManager::new().unwrap();
     let results = process_manager.find_processes("/cargo", FilterOptions::default());
     assert!(!results.is_empty());
-    assert!(results.iter().all(|p| p
-        .cmd_path
-        .as_ref()
-        .expect(format!("failed: {:?}", results).as_str())
-        .contains("cargo")));
+    assert!(results
+        .iter()
+        .all(|p| p.cmd_path.as_ref().expect("what?").contains("cargo")));
 }
 
 #[test]


### PR DESCRIPTION
Addresses #2 

# What

- Introduce fuzzy search for `Cmd` types of queries only.
- It means we are still lowering the query string for the rest of the query types