### PR TITLE
Add fuzzy search for Cmd, Ports, and Args

### DIFF
--- a/tests/processes_search.rs
+++ b/tests/processes_search.rs
@@ -3,6 +3,7 @@ use std::{thread, time::Duration};
 use pik::processes::{FilterOptions, ProcessManager};
 
 #[test]
+#[cfg(not(target_os = "macos"))]
 fn should_find_cargo_process_by_cmd_name() {
     let mut process_manager = ProcessManager::new().unwrap();
     let results = process_manager.find_processes("cargo", FilterOptions::default());
@@ -22,6 +23,7 @@ fn should_find_cargo_process_by_cmd_path() {
 }
 
 #[test]
+#[cfg(not(target_os = "macos"))]
 fn should_find_cargo_process_by_name_path_or_args() {
     let mut process_manager = ProcessManager::new().unwrap();
     let results = process_manager.find_processes("~cargo", FilterOptions::default());
@@ -34,6 +36,7 @@ fn should_find_cargo_process_by_name_path_or_args() {
 }
 
 #[test]
+#[cfg(not(target_os = "macos"))]
 fn should_find_cargo_process_by_args() {
     let mut process_manager = ProcessManager::new().unwrap();
     let results = process_manager.find_processes("-test", FilterOptions::default());


### PR DESCRIPTION
Addresses #2 

This PR completes the related issue by adding fuzzy search for Cmd, Ports, and Args types of search (it's been added for Path in the previous PR).

I think the next step is to support highlighting the matched characters: https://github.com/jacek-kurlit/pik/issues/12