### PR TITLE
ctrl+{home|end} go to first|last item

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,22 +118,23 @@ Please refer to [config](config.md) for more details about configuration options
 
 ### Key maps
 
-| Key(s)                                   | Action                        |
-| ---------------------------------------- | ----------------------------- |
-| `Esc` \| `Ctrl + C`                      | Quit                          |
-| `Ctrl + X`                               | Kill process                  |
-| `Ctrl + R`                               | Refresh processes list        |
-| `Ctrl + F`                               | Details forward               |
-| `Ctrl + B`                               | Details backward              |
-| `Ctrl + Y`                               | Copy process pid to clipboard |
-| `Tab` \| `Shift + Tab`                   | Select next/previous          |
-| `Arrow Down` \| `Arrow Up`               | Select next/previous          |
-| `Ctrl + J` \| `Ctrl + K`                 | Select next/previous          |
-| `Ctrl + N` \| `Ctrl + P`                 | Select next/previous          |
-| `Ctrl + Arrow Down` \| `Ctrl + Arrow Up` | Select last/first             |
-| `Alt + P`                                | Select parent process         |
-| `Alt + F`                                | Select familly processes      |
-| `Alt + S`                                | Select siblings processes     |
+| Key(s)                                                 | Action                        |
+| ------------------------------------------------------ | ----------------------------- |
+| <kbd>Esc</kbd> \| <kbd>Ctrl+C</kbd>                    | Quit                          |
+| <kbd>Ctrl+X</kbd>                                      | Kill process                  |
+| <kbd>Ctrl+R</kbd>                                      | Refresh processes list        |
+| <kbd>Ctrl+F</kbd>                                      | Details forward               |
+| <kbd>Ctrl+B</kbd>                                      | Details backward              |
+| <kbd>Ctrl+Y</kbd>                                      | Copy process pid to clipboard |
+| <kbd>Tab</kbd> \| <kbd>Shift+Tab</kbd>                 | Select next/previous          |
+| <kbd>Arrow Down</kbd> \| <kbd>Arrow Up</kbd>           | Select next/previous          |
+| <kbd>Ctrl+J</kbd> \| <kbd>Ctrl+K</kbd>                 | Select next/previous          |
+| <kbd>Ctrl+N</kbd> \| <kbd>Ctrl+P</kbd>                 | Select next/previous          |
+| <kbd>Ctrl+Arrow Down</kbd> \| <kbd>Ctrl+Arrow Up</kbd> | Select last/first             |
+| <kbd>Ctrl+End</kbd> \| <kbd>Ctrl+Home</kbd>            | Select last/first             |
+| <kbd>Alt+P</kbd>                                       | Select parent process         |
+| <kbd>Alt+F</kbd>                                       | Select familly processes      |
+| <kbd>Alt+S</kbd>                                       | Select siblings processes     |
 
 ## Caveats
 

--- a/src/tui/components/processes_view.rs
+++ b/src/tui/components/processes_view.rs
@@ -154,22 +154,36 @@ impl Component for ProcessesViewComponent {
     fn handle_input(&mut self, key: KeyEvent) -> KeyAction {
         use KeyCode::*;
         match key.code {
-            Up if key.modifiers.contains(KeyModifiers::CONTROL) => self.select_first_row(),
-            Down if key.modifiers.contains(KeyModifiers::CONTROL) => self.select_last_row(),
+            Up | Home
+                if key
+                    .modifiers
+                    .contains(KeyModifiers::CONTROL) =>
+            {
+                self.select_first_row()
+            },
+            Down | End
+                if key
+                    .modifiers
+                    .contains(KeyModifiers::CONTROL) =>
+            {
+                self.select_last_row()
+            },
             Up | BackTab => self.select_previous_row(1),
-            Tab | Down => self.select_next_row(1),
+            Down | Tab => self.select_next_row(1),
             PageUp => self.select_previous_row(10),
             PageDown => self.select_next_row(10),
-            Char('j') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            Char('j') | Char('n')
+                if key
+                    .modifiers
+                    .contains(KeyModifiers::CONTROL) =>
+            {
                 self.select_next_row(1);
-            }
-            Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                self.select_next_row(1);
-            }
-            Char('k') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                self.select_previous_row(1);
-            }
-            Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            },
+            Char('k') | Char('p')
+                if key
+                    .modifiers
+                    .contains(KeyModifiers::CONTROL) =>
+            {
                 self.select_previous_row(1);
             }
             Char('x') if key.modifiers.contains(KeyModifiers::CONTROL) => {


### PR DESCRIPTION
I don't remember seeing <kbd>ctrl+[↑↓]</kbd> be documented anywhere, but they're a very neat idea! Having hotkeys to go to the first / last item. However a more natural hotkey combination for those two, for me, is <kbd>ctrl+home</kbd> / <kbd>ctrl+end</kbd>. \
Gui places tend to use those to mean "go to the absolute up" and "go to the absolute down", after all.

I was worrying that ctrl + home wouldn't work because of the context of the terminal, but nope! Surprisingly, works as expected (I tested it). \
Of course, I simply *added* these two hotkeys; I did not remove the <kbd>ctrl+[↑↓]</kbd> ones, as I have a feeling you made those because *you* like them ;) (as a dev, I do this all the time haha)

Also did some other insignificant cleanup in the same file. Really glad to see we're getting a "copy pid to clipboard" feature being worked on. Doesn't work yet it seems, tell me if this is unexpected.
