### PR TITLE
fix part of #166

### DIFF
--- a/src/tui/components/help_popup.rs
+++ b/src/tui/components/help_popup.rs
@@ -124,8 +124,8 @@ impl Component for HelpPopupComponent {
             .highlight_style(self.theme.selected_row)
             .highlight_spacing(HighlightSpacing::Always);
 
-        let area = popup_area(area, 30, 80);
         frame.render_widget(Clear, area); //this clears out the background
+        let area = popup_area(area, 35, 80);
         frame.render_stateful_widget(list, area, &mut self.list_state);
     }
 }

--- a/src/tui/components/help_popup.rs
+++ b/src/tui/components/help_popup.rs
@@ -111,7 +111,12 @@ impl Component for HelpPopupComponent {
         let block = Block::bordered()
             .title_top(Line::from(" Keybindings ").centered())
             .title_bottom(Line::from(" Press <Esc> to close ").centered())
-            .padding(Padding::left(1))
+            .padding(Padding {
+                left: 1,
+                right: 1,
+                top: 0,
+                bottom: 0,
+            })
             .border_style(self.theme.border.style)
             .border_type(self.theme.border._type);
         let list = List::new(self.create_list_items())


### PR DESCRIPTION
I played around with the idea to fix the width mismatch, but it's above my paygrade. What I thought of doing would complicate the process of creating the elements and all that jazz, by us having to report the width of each line to then calculate the size of the biggest line, for that to be used. Would be one ugly pr, so I considered simply changing the width percentage. And sure, 35% works better for me, but then we zoom in even higher and it's broken again. And zooming out more and more makes the help popup look goofier and goofier. \
So I think this is a problem with the overall layout. I with it would basically fit-content() horizontally, but no clue if ratatui has that kind of thing, I'm not familiar
