### PR TITLE
feat(tui): Add readline-style keybindings for search bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,16 @@ This tool is still under development
 
 ## Table of Contents
 
+- [Table of Contents](#table-of-contents)
 - [Features](#features)
 - [Installation](#installation)
 - [Configuration](#configuration)
+  - [Application configuration](#application-configuration)
 - [Caveats](#caveats)
 - [Development](#development)
+  - [Supported Systems](#supported-systems)
+  - [Setup](#setup)
+  - [Building](#building)
 
 ## Features
 
@@ -44,6 +49,7 @@ Pik allows to **fuzzy** search processes by:
   ![Example search everywhere](docs/search_everywhere.gif)
 - Select exact process by id - Prefix with '!' for example '!1234'
 - Select process family (process + it's children) - Prefix with '@' for example '@1234'
+- Support the [readline style keybindings](https://readline.kablamo.org/emacs.html) for text input in search bar
 
 After selecting process you can kill it with Ctrl + X
 

--- a/src/tui/components/processes_view.rs
+++ b/src/tui/components/processes_view.rs
@@ -242,6 +242,12 @@ impl Component for ProcessesViewComponent {
             AppAction::CursorEnd => {
                 self.search_bar.move_cursor(CursorMove::End);
             }
+            AppAction::CursorWordLeft => {
+                self.search_bar.move_cursor(CursorMove::WordBack);
+            }
+            AppAction::CursorWordRight => {
+                self.search_bar.move_cursor(CursorMove::WordForward);
+            }
             AppAction::DeleteChar => {
                 self.search_bar.delete_char();
                 return self.search_for_processess();
@@ -257,6 +263,14 @@ impl Component for ProcessesViewComponent {
             }
             AppAction::DeleteToStart => {
                 self.search_bar.delete_to_start();
+                return self.search_for_processess();
+            }
+            AppAction::DeleteToEnd => {
+                self.search_bar.delete_to_end();
+                return self.search_for_processess();
+            }
+            AppAction::DeleteNextWord => {
+                self.search_bar.delete_next_word();
                 return self.search_for_processess();
             }
             AppAction::Unmapped => {

--- a/src/tui/components/search_bar.rs
+++ b/src/tui/components/search_bar.rs
@@ -52,6 +52,14 @@ impl SearchBarComponent {
         self.search_area.delete_line_by_head();
     }
 
+    pub fn delete_to_end(&mut self) {
+        self.search_area.delete_line_by_end();
+    }
+
+    pub fn delete_next_word(&mut self) {
+        self.search_area.delete_next_word();
+    }
+
     pub fn set_search_text(&mut self, text: &str) {
         self.clear_search_area();
         self.search_area.insert_str(text);


### PR DESCRIPTION
- Enhance key mappings to support multiple modifiers and new cursor actions
- Implement word-level cursor movements and advanced deletions in search bar
- Add tests for deserializing key bindings with multiple modifiers