### PR TITLE
bug: correct line count calculation for process details scrolling

### DIFF
--- a/src/tui/components/process_details.rs
+++ b/src/tui/components/process_details.rs
@@ -3,6 +3,7 @@ use ratatui::{
     text::Line,
     widgets::{Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState, Wrap},
 };
+use unicode_width::UnicodeWidthStr;
 
 use crate::{config::ui::ProcessDetailsTheme, processes::Process, tui::LayoutRects};
 
@@ -45,6 +46,36 @@ impl ProcessDetailsComponent {
         self.process_details_scroll_offset = 0;
     }
 
+    fn calculate_wrapped_lines(text: &str, width: u16) -> u16 {
+        if text.is_empty() {
+            return 1;
+        }
+        let width = width as usize;
+
+        // Simulate word wrapping similar to ratatui's Paragraph
+        let mut line_count = 0;
+        let mut current_line_width = 0;
+
+        for word in text.split_inclusive(' ') {
+            let word_width = word.width();
+
+            if current_line_width == 0 {
+                // First word on the line
+                current_line_width = word_width;
+                line_count += 1;
+            } else if current_line_width + word_width <= width {
+                // Word fits on current line
+                current_line_width += word_width;
+            } else {
+                // Word needs a new line
+                current_line_width = word_width;
+                line_count += 1;
+            }
+        }
+
+        line_count.max(1) as u16
+    }
+
     fn update_process_details_number_of_lines(
         &mut self,
         selected_process: Option<&Process>,
@@ -54,9 +85,36 @@ impl ProcessDetailsComponent {
 
         match selected_process.as_ref() {
             Some(process) => {
-                let args_number_of_lines =
-                    (process.args.chars().count() as u16 / content_width) + 1;
-                self.process_details_number_of_lines = args_number_of_lines + 2;
+                // rebuild to-be-rendered lines to calculate their wrapped height
+                let ports = process
+                    .ports
+                    .as_deref()
+                    .map(|p| format!(" PORTS: {p}"))
+                    .unwrap_or("".to_string());
+                let parent = process
+                    .parent_pid
+                    .map(|p| format!(" PARENT: {p}"))
+                    .unwrap_or("".to_string());
+
+                let line1 = format!(
+                    "USER: {} PID: {}{} START TIME: {}, RUN TIME: {} MEMORY: {}MB{}",
+                    process.user_name,
+                    process.pid,
+                    parent,
+                    process.start_time,
+                    process.run_time,
+                    process.memory / 1024 / 1024,
+                    ports,
+                );
+                let line2 = format!("CMD: {}", process.exe());
+                let line3 = format!("ARGS: {}", process.args);
+
+                let line1_wrapped = Self::calculate_wrapped_lines(&line1, content_width);
+                let line2_wrapped = Self::calculate_wrapped_lines(&line2, content_width);
+                let line3_wrapped = Self::calculate_wrapped_lines(&line3, content_width);
+
+                self.process_details_number_of_lines =
+                    line1_wrapped + line2_wrapped + line3_wrapped;
             }
             None => {
                 self.process_details_number_of_lines = 1;


### PR DESCRIPTION
The process details view was truncating long arguments because the line count calculation didn't account for how ratatui's Paragraph widget actually wraps text at word boundaries.

Changes:
- Add word-aware wrapping in calculate_wrapped_lines()
- Calculate wrapped line counts for all three detail lines (USER, CMD, ARGS)
- Use unicode-width for accurate display width calculation

Resolves #194