### PR TITLE
Replace '!' for selecting process by pid with '='

### DIFF
--- a/src/processes/filters.rs
+++ b/src/processes/filters.rs
@@ -29,7 +29,7 @@ impl QueryFilter {
             Some('/') => (SearchBy::Path, &query[1..]),
             Some('-') => (SearchBy::Args, &query[1..]),
             Some('~') => (SearchBy::Everywhere, &query[1..]),
-            Some('!') => (SearchBy::Pid, &query[1..]),
+            Some('=') => (SearchBy::Pid, &query[1..]),
             Some('@') => (SearchBy::ProcessFamily, &query[1..]),
             Some(_) => (SearchBy::Cmd, query),
             None => (SearchBy::None, query),
@@ -200,7 +200,7 @@ pub mod tests {
         assert_eq!(filter.search_by, SearchBy::Everywhere);
         assert_eq!(filter.query, "foo");
 
-        let filter = QueryFilter::new("!1234");
+        let filter = QueryFilter::new("=1234");
         assert_eq!(filter.search_by, SearchBy::Pid);
         assert_eq!(filter.query, "1234");
 
@@ -341,7 +341,7 @@ pub mod tests {
 
     #[test]
     fn query_filter_search_by_pid() {
-        let filter = QueryFilter::new("!1234");
+        let filter = QueryFilter::new("=1234");
         let mut process = MockProcessInfo {
             pid: 1234,
             ..Default::default()

--- a/tests/processes_search.rs
+++ b/tests/processes_search.rs
@@ -82,7 +82,7 @@ fn should_find_cargo_process_by_pid() {
     let cargo_process_pid = results.nth(Some(0)).map(|r| r.pid).unwrap();
 
     let restults =
-        process_manager.find_processes(&format!("!{cargo_process_pid}"), &IgnoreOptions::default());
+        process_manager.find_processes(&format!("={cargo_process_pid}"), &IgnoreOptions::default());
     assert_eq!(restults.len(), 1);
     assert_eq!(restults.nth(Some(0)).unwrap().pid, cargo_process_pid);
     assert!(results_are_sorted_by_match_type(results));


### PR DESCRIPTION
Should close jacek-kurlit/pik#209

- Replaced ! with = in filters
- Modified tests

I tested the changes with the automated tests using `cargo test` and a manual test after `cargo build --release`