### PR TITLE
TUI Notifications

### DIFF
--- a/default_config.toml
+++ b/default_config.toml
@@ -90,12 +90,14 @@ selected_row = { bg = "#1e293b", add_modifier = "BOLD" }
 primary = { fg = "#60A5FA" }
 secondary = {}
 
-[ui.notifications.border]
+[ui.notifications]
+timeout_ms = 2500
+
+[ui.notifications.theme.border]
 type = "rounded"
 style = { fg = "#64748b" }
 
-[ui.notifications]
-timeout_ms = 2500
+[ui.notifications.theme]
 info = { fg = "#93c5fd" }
 success = { fg = "#4ade80" }
 error = { fg = "#f87171" }

--- a/default_config.toml
+++ b/default_config.toml
@@ -89,3 +89,13 @@ style = { fg = "#4ade80" }
 selected_row = { bg = "#1e293b", add_modifier = "BOLD" }
 primary = { fg = "#60A5FA" }
 secondary = {}
+
+[ui.notifications.border]
+type = "rounded"
+style = { fg = "#64748b" }
+
+[ui.notifications]
+timeout_ms = 2500
+info = { fg = "#93c5fd" }
+success = { fg = "#4ade80" }
+error = { fg = "#f87171" }

--- a/src/config.rs
+++ b/src/config.rs
@@ -167,8 +167,8 @@ mod tests {
         widgets::{BorderType, TitlePosition},
     };
     use ui::{
-        BorderTheme, CellTheme, ProcessDetailsTheme, RowTheme, ScrollbarTheme, SearchBarTheme,
-        TableTheme, TitleTheme,
+        BorderTheme, CellTheme, NotificationsTheme, ProcessDetailsTheme, RowTheme, ScrollbarTheme,
+        SearchBarTheme, TableTheme, TitleTheme,
     };
 
     use crate::config::{
@@ -263,6 +263,16 @@ mod tests {
                         selected_row: Style::new().bg(SLATE.c800).add_modifier(Modifier::BOLD),
                         primary: Style::new().fg(tailwind::BLUE.c400),
                         secondary: Style::default(),
+                    },
+                    notifications: NotificationsTheme {
+                        border: BorderTheme {
+                            style: Style::default().fg(tailwind::SLATE.c500),
+                            _type: BorderType::Rounded,
+                        },
+                        info: Style::new().fg(tailwind::BLUE.c300),
+                        success: Style::new().fg(tailwind::GREEN.c400),
+                        error: Style::new().fg(tailwind::RED.c400),
+                        timeout_ms: 2500,
                     }
                 }
             }
@@ -339,6 +349,13 @@ mod tests {
             selected_row = {fg = "#57534e", bg = "#fafaf9", add_modifier = "ITALIC"}
             primary = {fg = "#f472b6", bg = "#4c1d95", add_modifier = "BOLD"}
             secondary = {fg = "#a5f3fc", bg = "#0891b2", add_modifier = "CROSSED_OUT"}
+
+            [ui.notifications]
+            timeout_ms = 1500
+            border = {type = "plain", style = {fg = "#6366f1", add_modifier = "BOLD | ITALIC"}}
+            info = {fg = "#a5f3fc", bg = "#0891b2", add_modifier = "CROSSED_OUT"}
+            success = {fg = "#4ade80", bg = "#14532d", add_modifier = "BOLD"}
+            error = {fg = "#f87171", bg = "#450a0a", add_modifier = "ITALIC"}
             "##,
         )
         .expect("This should be parseable");
@@ -463,6 +480,25 @@ mod tests {
                             .fg(tailwind::CYAN.c200)
                             .bg(tailwind::CYAN.c600)
                             .crossed_out(),
+                    },
+                    notifications: NotificationsTheme {
+                        border: BorderTheme {
+                            style: Style::default().fg(tailwind::INDIGO.c500).bold().italic(),
+                            _type: BorderType::Plain,
+                        },
+                        info: Style::new()
+                            .fg(tailwind::CYAN.c200)
+                            .bg(tailwind::CYAN.c600)
+                            .crossed_out(),
+                        success: Style::new()
+                            .fg(tailwind::GREEN.c400)
+                            .bg(Color::Rgb(20, 83, 45))
+                            .bold(),
+                        error: Style::new()
+                            .fg(tailwind::RED.c400)
+                            .bg(tailwind::RED.c950)
+                            .italic(),
+                        timeout_ms: 1500,
                     }
                 }
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -167,8 +167,8 @@ mod tests {
         widgets::{BorderType, TitlePosition},
     };
     use ui::{
-        BorderTheme, CellTheme, NotificationsTheme, ProcessDetailsTheme, RowTheme, ScrollbarTheme,
-        SearchBarTheme, TableTheme, TitleTheme,
+        BorderTheme, CellTheme, NotificationsConfig, NotificationsTheme, ProcessDetailsTheme,
+        RowTheme, ScrollbarTheme, SearchBarTheme, TableTheme, TitleTheme,
     };
 
     use crate::config::{
@@ -264,15 +264,17 @@ mod tests {
                         primary: Style::new().fg(tailwind::BLUE.c400),
                         secondary: Style::default(),
                     },
-                    notifications: NotificationsTheme {
-                        border: BorderTheme {
-                            style: Style::default().fg(tailwind::SLATE.c500),
-                            _type: BorderType::Rounded,
-                        },
-                        info: Style::new().fg(tailwind::BLUE.c300),
-                        success: Style::new().fg(tailwind::GREEN.c400),
-                        error: Style::new().fg(tailwind::RED.c400),
+                    notifications: NotificationsConfig {
                         timeout_ms: 2500,
+                        theme: NotificationsTheme {
+                            border: BorderTheme {
+                                style: Style::default().fg(tailwind::SLATE.c500),
+                                _type: BorderType::Rounded,
+                            },
+                            info: Style::new().fg(tailwind::BLUE.c300),
+                            success: Style::new().fg(tailwind::GREEN.c400),
+                            error: Style::new().fg(tailwind::RED.c400),
+                        },
                     }
                 }
             }
@@ -352,10 +354,15 @@ mod tests {
 
             [ui.notifications]
             timeout_ms = 1500
-            border = {type = "plain", style = {fg = "#6366f1", add_modifier = "BOLD | ITALIC"}}
+            
+            [ui.notifications.theme]
             info = {fg = "#a5f3fc", bg = "#0891b2", add_modifier = "CROSSED_OUT"}
             success = {fg = "#4ade80", bg = "#14532d", add_modifier = "BOLD"}
             error = {fg = "#f87171", bg = "#450a0a", add_modifier = "ITALIC"}
+
+            [ui.notifications.theme.border]
+            type = "plain"
+            style = {fg = "#6366f1", add_modifier = "BOLD | ITALIC"}
             "##,
         )
         .expect("This should be parseable");
@@ -481,24 +488,26 @@ mod tests {
                             .bg(tailwind::CYAN.c600)
                             .crossed_out(),
                     },
-                    notifications: NotificationsTheme {
-                        border: BorderTheme {
-                            style: Style::default().fg(tailwind::INDIGO.c500).bold().italic(),
-                            _type: BorderType::Plain,
-                        },
-                        info: Style::new()
-                            .fg(tailwind::CYAN.c200)
-                            .bg(tailwind::CYAN.c600)
-                            .crossed_out(),
-                        success: Style::new()
-                            .fg(tailwind::GREEN.c400)
-                            .bg(Color::Rgb(20, 83, 45))
-                            .bold(),
-                        error: Style::new()
-                            .fg(tailwind::RED.c400)
-                            .bg(tailwind::RED.c950)
-                            .italic(),
+                    notifications: NotificationsConfig {
                         timeout_ms: 1500,
+                        theme: NotificationsTheme {
+                            border: BorderTheme {
+                                style: Style::default().fg(tailwind::INDIGO.c500).bold().italic(),
+                                _type: BorderType::Plain,
+                            },
+                            info: Style::new()
+                                .fg(tailwind::CYAN.c200)
+                                .bg(tailwind::CYAN.c600)
+                                .crossed_out(),
+                            success: Style::new()
+                                .fg(tailwind::GREEN.c400)
+                                .bg(Color::Rgb(20, 83, 45))
+                                .bold(),
+                            error: Style::new()
+                                .fg(tailwind::RED.c400)
+                                .bg(tailwind::RED.c950)
+                                .italic(),
+                        },
                     }
                 }
             }

--- a/src/config/ui.rs
+++ b/src/config/ui.rs
@@ -22,6 +22,8 @@ pub struct UIConfig {
     pub search_bar: SearchBarTheme,
     #[serde(default)]
     pub popups: PopupsTheme,
+    #[serde(default)]
+    pub notifications: NotificationsTheme,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq, Eq)]
@@ -309,6 +311,39 @@ impl Default for PopupsTheme {
             selected_row: Style::new().bg(SLATE.c800).add_modifier(Modifier::BOLD),
             primary: Style::new().fg(tailwind::BLUE.c400),
             secondary: Style::default(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub struct NotificationsTheme {
+    #[serde(default)]
+    pub border: BorderTheme,
+    #[serde(default, with = "StyleDef")]
+    pub info: Style,
+    #[serde(default, with = "StyleDef")]
+    pub success: Style,
+    #[serde(default, with = "StyleDef")]
+    pub error: Style,
+    #[serde(default = "default_notification_timeout_ms")]
+    pub timeout_ms: u64,
+}
+
+const fn default_notification_timeout_ms() -> u64 {
+    2500
+}
+
+impl Default for NotificationsTheme {
+    fn default() -> Self {
+        Self {
+            border: BorderTheme {
+                style: Style::new().fg(tailwind::SLATE.c500),
+                ..Default::default()
+            },
+            info: Style::new().fg(tailwind::BLUE.c300),
+            success: Style::new().fg(tailwind::GREEN.c400),
+            error: Style::new().fg(tailwind::RED.c400),
+            timeout_ms: default_notification_timeout_ms(),
         }
     }
 }

--- a/src/config/ui.rs
+++ b/src/config/ui.rs
@@ -23,7 +23,7 @@ pub struct UIConfig {
     #[serde(default)]
     pub popups: PopupsTheme,
     #[serde(default)]
-    pub notifications: NotificationsTheme,
+    pub notifications: NotificationsConfig,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq, Eq)]
@@ -316,6 +316,27 @@ impl Default for PopupsTheme {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub struct NotificationsConfig {
+    #[serde(default = "default_notification_timeout_ms")]
+    pub timeout_ms: u64,
+    #[serde(default)]
+    pub theme: NotificationsTheme,
+}
+
+const fn default_notification_timeout_ms() -> u64 {
+    2500
+}
+
+impl Default for NotificationsConfig {
+    fn default() -> Self {
+        Self {
+            timeout_ms: default_notification_timeout_ms(),
+            theme: NotificationsTheme::default(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct NotificationsTheme {
     #[serde(default)]
     pub border: BorderTheme,
@@ -325,12 +346,6 @@ pub struct NotificationsTheme {
     pub success: Style,
     #[serde(default, with = "StyleDef")]
     pub error: Style,
-    #[serde(default = "default_notification_timeout_ms")]
-    pub timeout_ms: u64,
-}
-
-const fn default_notification_timeout_ms() -> u64 {
-    2500
 }
 
 impl Default for NotificationsTheme {
@@ -343,7 +358,6 @@ impl Default for NotificationsTheme {
             info: Style::new().fg(tailwind::BLUE.c300),
             success: Style::new().fg(tailwind::GREEN.c400),
             error: Style::new().fg(tailwind::RED.c400),
-            timeout_ms: default_notification_timeout_ms(),
         }
     }
 }

--- a/src/processes/daemon.rs
+++ b/src/processes/daemon.rs
@@ -51,14 +51,27 @@ impl ProcssAsyncService {
 
 pub enum Operations {
     Search(String),
-    KillProcess { pid: u32, graceful: bool },
+    KillProcess {
+        pid: u32,
+        graceful: bool,
+        name: String,
+    },
     Shutdown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KilledProcess {
+    pub pid: u32,
+    pub name: String,
 }
 
 #[derive(Debug)]
 pub enum OperationResult {
-    ProcessKilled(ProcessSearchResults),
-    ProcessKillFailed,
+    ProcessKilled {
+        results: ProcessSearchResults,
+        process: KilledProcess,
+    },
+    ProcessKillFailed(KilledProcess),
     SearchCompleted(ProcessSearchResults),
     Error(String),
 }
@@ -83,17 +96,25 @@ fn process_loop(
                     let result = service.refresh_and_find_processes(&query);
                     send_result(OperationResult::SearchCompleted(result), &result_sender);
                 }
-                Operations::KillProcess { pid, graceful } => {
+                Operations::KillProcess {
+                    pid,
+                    graceful,
+                    name,
+                } => {
+                    let process = KilledProcess { pid, name };
                     if service.process_manager.kill_process(pid, graceful) {
                         let mut search_results = service.rerun_last_search();
                         //NOTE: cache refresh takes time and process may reappear in list!
                         search_results.remove(pid);
                         send_result(
-                            OperationResult::ProcessKilled(search_results),
+                            OperationResult::ProcessKilled {
+                                results: search_results,
+                                process,
+                            },
                             &result_sender,
                         );
                     } else {
-                        send_result(OperationResult::ProcessKillFailed, &result_sender);
+                        send_result(OperationResult::ProcessKillFailed(process), &result_sender);
                     }
                 }
                 Operations::Shutdown => {
@@ -230,6 +251,7 @@ mod tests {
         let mut process_manager = ProcessManager::faux();
         let pid = 1000;
         let graceful = true;
+        let name = "pik".to_string();
         faux::when!(process_manager.kill_process(pid, graceful)).then_return(true);
         faux::when!(process_manager.find_processes("", ignore_options))
             .then(|_| ProcessSearchResults::empty());
@@ -241,7 +263,11 @@ mod tests {
 
         // when
         operation_sender
-            .send(crate::processes::Operations::KillProcess { pid, graceful })
+            .send(crate::processes::Operations::KillProcess {
+                pid,
+                graceful,
+                name: name.clone(),
+            })
             .unwrap();
 
         // then
@@ -250,7 +276,10 @@ mod tests {
             .unwrap();
         assert!(matches!(
             actual,
-            crate::processes::OperationResult::ProcessKilled(_)
+            crate::processes::OperationResult::ProcessKilled {
+                process: crate::processes::KilledProcess { pid: 1000, name: _ },
+                ..
+            }
         ));
     }
 
@@ -260,6 +289,7 @@ mod tests {
         let mut process_manager = ProcessManager::faux();
         let pid = 1000;
         let graceful = false;
+        let name = "pik".to_string();
         faux::when!(process_manager.kill_process(pid, graceful)).then_return(false);
 
         let (operation_sender, result_receiver) =
@@ -268,7 +298,11 @@ mod tests {
 
         // when
         operation_sender
-            .send(crate::processes::Operations::KillProcess { pid, graceful })
+            .send(crate::processes::Operations::KillProcess {
+                pid,
+                graceful,
+                name: name.clone(),
+            })
             .unwrap();
 
         // then
@@ -277,7 +311,10 @@ mod tests {
             .unwrap();
         assert!(matches!(
             actual,
-            crate::processes::OperationResult::ProcessKillFailed
+            crate::processes::OperationResult::ProcessKillFailed(crate::processes::KilledProcess {
+                pid: 1000,
+                name: _
+            })
         ));
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -8,7 +8,8 @@ use anyhow::{Context, Result, anyhow};
 use components::{
     Component, ComponentEvent, KeyAction, debug::DebugComponent,
     general_input_handler::GeneralInputHandlerComponent, help_footer::HelpFooterComponent,
-    help_popup::HelpPopupComponent, processes_view::ProcessesViewComponent,
+    help_popup::HelpPopupComponent, notifications::NotificationsComponent,
+    processes_view::ProcessesViewComponent,
 };
 use ratatui::crossterm::{
     event::{self, Event, KeyEventKind},
@@ -46,6 +47,9 @@ impl App {
                 Box::new(HelpPopupComponent::new(
                     &app_settings.ui_config,
                     &app_settings.key_mappings,
+                )),
+                Box::new(NotificationsComponent::new(
+                    &app_settings.ui_config.notifications,
                 )),
                 Box::new(GeneralInputHandlerComponent),
                 Box::new(HelpFooterComponent::new(&app_settings.key_mappings)),

--- a/src/tui/components.rs
+++ b/src/tui/components.rs
@@ -87,13 +87,6 @@ pub enum KeyAction {
 }
 
 pub enum ComponentEvent {
-    ProcessListRefreshRequested,
-    ProcessListRefreshed,
-    NoProcessToKill,
-    ProcessKillRequested,
-    ProcessKilled,
-    ProcessKillFailed,
     QuitRequested,
-    ErrorOccurred(String),
     ShowNotification(Notification),
 }

--- a/src/tui/components.rs
+++ b/src/tui/components.rs
@@ -9,10 +9,57 @@ pub mod debug;
 pub mod general_input_handler;
 pub mod help_footer;
 pub mod help_popup;
+pub mod notifications;
 pub mod process_details;
 pub mod process_table;
 pub mod processes_view;
 pub mod search_bar;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NotificationSeverity {
+    Info,
+    Success,
+    Error,
+}
+
+impl NotificationSeverity {
+    pub const fn title(&self) -> &'static str {
+        match self {
+            Self::Info => " Info ",
+            Self::Success => " Success ",
+            Self::Error => " Error ",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Notification {
+    pub message: String,
+    pub severity: NotificationSeverity,
+}
+
+impl Notification {
+    pub fn info(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            severity: NotificationSeverity::Info,
+        }
+    }
+
+    pub fn success(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            severity: NotificationSeverity::Success,
+        }
+    }
+
+    pub fn error(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            severity: NotificationSeverity::Error,
+        }
+    }
+}
 
 pub trait Component {
     fn handle_input(&mut self, _original: KeyEvent, _app_action: AppAction) -> KeyAction {
@@ -48,4 +95,5 @@ pub enum ComponentEvent {
     ProcessKillFailed,
     QuitRequested,
     ErrorOccurred(String),
+    ShowNotification(Notification),
 }

--- a/src/tui/components/help_footer.rs
+++ b/src/tui/components/help_footer.rs
@@ -1,21 +1,13 @@
-use std::borrow::Cow;
-
-use ratatui::{
-    layout::{Constraint, Layout},
-    style::{Color, Stylize},
-    text::{Line, Span},
-    widgets::{Block, Borders, Paragraph},
-};
+use ratatui::{text::Line, widgets::Paragraph};
 
 use crate::{
     config::keymappings::{AppAction, KeyMappings},
     tui::LayoutRects,
 };
 
-use super::{Component, ComponentEvent};
+use super::Component;
 
 pub struct HelpFooterComponent {
-    error_message: Cow<'static, str>,
     help_bar: Paragraph<'static>,
 }
 
@@ -29,49 +21,12 @@ impl HelpFooterComponent {
             "{quit}/{close} quit | {kill_process} kill process | {help_toggle} toggle help"
         )))
         .centered();
-        Self {
-            error_message: Cow::Borrowed(""),
-            help_bar,
-        }
-    }
-
-    pub fn set_error_message(&mut self, message: Cow<'static, str>) {
-        self.error_message = message;
-    }
-
-    pub fn reset_error_message(&mut self) {
-        self.error_message = Cow::Borrowed("");
+        Self { help_bar }
     }
 }
 
 impl Component for HelpFooterComponent {
     fn render(&mut self, f: &mut ratatui::Frame, layout: &LayoutRects) {
-        let rects = Layout::horizontal([Constraint::Percentage(25), Constraint::Percentage(75)])
-            .horizontal_margin(1)
-            .split(layout.help_text);
-        let error = Paragraph::new(Span::from(self.error_message.as_ref()).fg(Color::Red))
-            .left_aligned()
-            .block(Block::default().borders(Borders::NONE));
-        f.render_widget(error, rects[0]);
-        f.render_widget(&self.help_bar, rects[1]);
-    }
-
-    fn handle_event(&mut self, event: &ComponentEvent) -> Option<ComponentEvent> {
-        match event {
-            ComponentEvent::ProcessListRefreshRequested => self.reset_error_message(),
-
-            ComponentEvent::ProcessKillRequested | ComponentEvent::NoProcessToKill => {
-                self.reset_error_message()
-            }
-            ComponentEvent::ProcessKillFailed => {
-                self.set_error_message(Cow::Borrowed("Failed to kill process. Check permissions"));
-            }
-            ComponentEvent::ErrorOccurred(error_message) => {
-                self.set_error_message(Cow::Owned(error_message.to_string()));
-            }
-            _ => (),
-        }
-
-        None
+        f.render_widget(&self.help_bar, layout.help_text);
     }
 }

--- a/src/tui/components/notifications.rs
+++ b/src/tui/components/notifications.rs
@@ -1,0 +1,174 @@
+use std::time::{Duration, Instant};
+
+use ratatui::{
+    layout::Rect,
+    style::Style,
+    text::{Line, Span},
+    widgets::{Block, Clear, Padding, Paragraph, Wrap},
+};
+
+use crate::{config::ui::NotificationsTheme, tui::LayoutRects};
+
+use super::{Component, ComponentEvent, Notification, NotificationSeverity};
+
+struct ActiveNotification {
+    notification: Notification,
+    shown_at: Instant,
+}
+
+pub struct NotificationsComponent {
+    active_notification: Option<ActiveNotification>,
+    theme: NotificationsTheme,
+}
+
+impl NotificationsComponent {
+    pub fn new(theme: &NotificationsTheme) -> Self {
+        Self {
+            active_notification: None,
+            theme: theme.clone(),
+        }
+    }
+
+    fn notification_style(&self, severity: &NotificationSeverity) -> Style {
+        match severity {
+            NotificationSeverity::Info => self.theme.info,
+            NotificationSeverity::Success => self.theme.success,
+            NotificationSeverity::Error => self.theme.error,
+        }
+    }
+
+    fn has_expired(&self, shown_at: Instant) -> bool {
+        shown_at.elapsed() >= Duration::from_millis(self.theme.timeout_ms)
+    }
+}
+
+impl Component for NotificationsComponent {
+    fn handle_event(&mut self, event: &ComponentEvent) -> Option<ComponentEvent> {
+        if let ComponentEvent::ShowNotification(notification) = event {
+            self.active_notification = Some(ActiveNotification {
+                notification: notification.clone(),
+                shown_at: Instant::now(),
+            });
+        }
+        None
+    }
+
+    fn update_state(&mut self) -> Option<ComponentEvent> {
+        if self
+            .active_notification
+            .as_ref()
+            .is_some_and(|notification| self.has_expired(notification.shown_at))
+        {
+            self.active_notification = None;
+        }
+
+        None
+    }
+
+    fn render(&mut self, frame: &mut ratatui::Frame, _layout: &LayoutRects) {
+        let Some(active_notification) = &self.active_notification else {
+            return;
+        };
+
+        let style = self.notification_style(&active_notification.notification.severity);
+        let area = notification_area(frame.area(), &active_notification.notification.message);
+        let block = Block::bordered()
+            .title_top(Line::from(Span::styled(
+                active_notification.notification.severity.title(),
+                style,
+            )))
+            .border_type(self.theme.border._type)
+            .border_style(self.theme.border.style)
+            .padding(Padding::horizontal(1));
+        let paragraph = Paragraph::new(active_notification.notification.message.as_str())
+            .style(style)
+            .block(block)
+            .wrap(Wrap { trim: true });
+
+        frame.render_widget(Clear, area);
+        frame.render_widget(paragraph, area);
+    }
+}
+
+fn notification_area(area: Rect, message: &str) -> Rect {
+    let max_width = area.width.saturating_sub(2).clamp(1, 60);
+    let min_width = max_width.min(24);
+    let width = (message.chars().count() as u16 + 4).clamp(min_width, max_width);
+    let inner_width = width.saturating_sub(4).max(1);
+    let wrapped_lines = message
+        .chars()
+        .count()
+        .div_ceil(inner_width as usize)
+        .max(1);
+    let height = (wrapped_lines as u16).min(3) + 2;
+    let x = area.right().saturating_sub(width + 1);
+    let y = area.y.saturating_add(1);
+
+    Rect::new(x, y, width, height)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, Instant};
+
+    use ratatui::style::{Color, Style};
+
+    use crate::config::ui::NotificationsTheme;
+
+    use super::*;
+
+    #[test]
+    fn replaces_previous_notification_with_latest_one() {
+        let mut component = NotificationsComponent::new(&NotificationsTheme::default());
+        component.handle_event(&ComponentEvent::ShowNotification(Notification::info(
+            "first",
+        )));
+        component.handle_event(&ComponentEvent::ShowNotification(Notification::error(
+            "second",
+        )));
+
+        let active = component.active_notification.as_ref().unwrap();
+        assert_eq!(active.notification.message, "second");
+        assert_eq!(active.notification.severity, NotificationSeverity::Error);
+    }
+
+    #[test]
+    fn clears_notification_after_timeout() {
+        let mut component = NotificationsComponent::new(&NotificationsTheme {
+            timeout_ms: 1,
+            ..NotificationsTheme::default()
+        });
+        component.active_notification = Some(ActiveNotification {
+            notification: Notification::info("expired"),
+            shown_at: Instant::now() - Duration::from_millis(5),
+        });
+
+        component.update_state();
+
+        assert!(component.active_notification.is_none());
+    }
+
+    #[test]
+    fn uses_severity_specific_style() {
+        let theme = NotificationsTheme {
+            info: Style::new().fg(Color::Blue),
+            success: Style::new().fg(Color::Green),
+            error: Style::new().fg(Color::Red),
+            ..NotificationsTheme::default()
+        };
+        let component = NotificationsComponent::new(&theme);
+
+        assert_eq!(
+            component.notification_style(&NotificationSeverity::Info),
+            theme.info
+        );
+        assert_eq!(
+            component.notification_style(&NotificationSeverity::Success),
+            theme.success
+        );
+        assert_eq!(
+            component.notification_style(&NotificationSeverity::Error),
+            theme.error
+        );
+    }
+}

--- a/src/tui/components/notifications.rs
+++ b/src/tui/components/notifications.rs
@@ -7,7 +7,7 @@ use ratatui::{
     widgets::{Block, Clear, Padding, Paragraph, Wrap},
 };
 
-use crate::{config::ui::NotificationsTheme, tui::LayoutRects};
+use crate::{config::ui::NotificationsConfig, tui::LayoutRects};
 
 use super::{Component, ComponentEvent, Notification, NotificationSeverity};
 
@@ -18,27 +18,27 @@ struct ActiveNotification {
 
 pub struct NotificationsComponent {
     active_notification: Option<ActiveNotification>,
-    theme: NotificationsTheme,
+    config: NotificationsConfig,
 }
 
 impl NotificationsComponent {
-    pub fn new(theme: &NotificationsTheme) -> Self {
+    pub fn new(config: &NotificationsConfig) -> Self {
         Self {
             active_notification: None,
-            theme: theme.clone(),
+            config: config.clone(),
         }
     }
 
     fn notification_style(&self, severity: &NotificationSeverity) -> Style {
         match severity {
-            NotificationSeverity::Info => self.theme.info,
-            NotificationSeverity::Success => self.theme.success,
-            NotificationSeverity::Error => self.theme.error,
+            NotificationSeverity::Info => self.config.theme.info,
+            NotificationSeverity::Success => self.config.theme.success,
+            NotificationSeverity::Error => self.config.theme.error,
         }
     }
 
     fn has_expired(&self, shown_at: Instant) -> bool {
-        shown_at.elapsed() >= Duration::from_millis(self.theme.timeout_ms)
+        shown_at.elapsed() >= Duration::from_millis(self.config.timeout_ms)
     }
 }
 
@@ -77,11 +77,10 @@ impl Component for NotificationsComponent {
                 active_notification.notification.severity.title(),
                 style,
             )))
-            .border_type(self.theme.border._type)
-            .border_style(self.theme.border.style)
+            .border_type(self.config.theme.border._type)
+            .border_style(self.config.theme.border.style)
             .padding(Padding::horizontal(1));
         let paragraph = Paragraph::new(active_notification.notification.message.as_str())
-            .style(style)
             .block(block)
             .wrap(Wrap { trim: true });
 
@@ -91,18 +90,18 @@ impl Component for NotificationsComponent {
 }
 
 fn notification_area(area: Rect, message: &str) -> Rect {
-    let max_width = area.width.saturating_sub(2).clamp(1, 60);
-    let min_width = max_width.min(24);
-    let width = (message.chars().count() as u16 + 4).clamp(min_width, max_width);
+    let max_width = area.width.saturating_sub(6).clamp(1, 72);
+    let min_width = max_width.min(36);
+    let width = (message.chars().count() as u16 + 8).clamp(min_width, max_width);
     let inner_width = width.saturating_sub(4).max(1);
     let wrapped_lines = message
         .chars()
         .count()
         .div_ceil(inner_width as usize)
         .max(1);
-    let height = (wrapped_lines as u16).min(3) + 2;
-    let x = area.right().saturating_sub(width + 1);
-    let y = area.y.saturating_add(1);
+    let height = (wrapped_lines as u16).min(4) + 2;
+    let x = area.right().saturating_sub(width + 3);
+    let y = area.y.saturating_add(2);
 
     Rect::new(x, y, width, height)
 }
@@ -113,13 +112,13 @@ mod tests {
 
     use ratatui::style::{Color, Style};
 
-    use crate::config::ui::NotificationsTheme;
+    use crate::config::ui::{NotificationsConfig, NotificationsTheme};
 
     use super::*;
 
     #[test]
     fn replaces_previous_notification_with_latest_one() {
-        let mut component = NotificationsComponent::new(&NotificationsTheme::default());
+        let mut component = NotificationsComponent::new(&NotificationsConfig::default());
         component.handle_event(&ComponentEvent::ShowNotification(Notification::info(
             "first",
         )));
@@ -134,9 +133,9 @@ mod tests {
 
     #[test]
     fn clears_notification_after_timeout() {
-        let mut component = NotificationsComponent::new(&NotificationsTheme {
+        let mut component = NotificationsComponent::new(&NotificationsConfig {
             timeout_ms: 1,
-            ..NotificationsTheme::default()
+            ..NotificationsConfig::default()
         });
         component.active_notification = Some(ActiveNotification {
             notification: Notification::info("expired"),
@@ -156,7 +155,10 @@ mod tests {
             error: Style::new().fg(Color::Red),
             ..NotificationsTheme::default()
         };
-        let component = NotificationsComponent::new(&theme);
+        let component = NotificationsComponent::new(&NotificationsConfig {
+            theme: theme.clone(),
+            ..NotificationsConfig::default()
+        });
 
         assert_eq!(
             component.notification_style(&NotificationSeverity::Info),

--- a/src/tui/components/processes_view.rs
+++ b/src/tui/components/processes_view.rs
@@ -8,7 +8,9 @@ use ratatui::crossterm::event::{KeyCode, KeyEvent};
 use tui_input::InputRequest;
 
 use crate::config::keymappings::AppAction;
-use crate::processes::{OperationResult, Operations, ProcessManager, ProcssAsyncService};
+use crate::processes::{
+    KilledProcess, OperationResult, Operations, ProcessManager, ProcssAsyncService,
+};
 use crate::tui::components::search_bar::CursorMove;
 use crate::{
     config::ui::UIConfig,
@@ -31,7 +33,6 @@ pub struct ProcessesViewComponent {
     process_table_component: ProcessTableComponent,
     process_details_component: ProcessDetailsComponent,
     search_bar: SearchBarComponent,
-    show_refresh_result_notification: bool,
 }
 
 // NOTE: clipboard access is initialized lazily because some systems do not provide a clipboard
@@ -69,7 +70,6 @@ impl ProcessesViewComponent {
                 &ui_config.search_bar,
                 ui_config.icons.get_icons().search_prompt.as_str(),
             ),
-            show_refresh_result_notification: false,
         };
         component.update_process_table_state();
         Ok(component)
@@ -110,11 +110,7 @@ impl ProcessesViewComponent {
             .update_process_table_state(number_of_items);
     }
 
-    fn search_for_processess(&mut self, triggered_by_refresh: bool) -> Result<(), Notification> {
-        update_refresh_notification_on_search_request(
-            &mut self.show_refresh_result_notification,
-            triggered_by_refresh,
-        );
+    fn search_for_processess(&mut self) -> Result<(), Notification> {
         let search_text = self.search_bar.get_search_text().to_string();
         match self.ops_sender.send(Operations::Search(search_text)) {
             Ok(_) => Ok(()),
@@ -127,10 +123,12 @@ impl ProcessesViewComponent {
     fn kill_selected_process(&mut self, graceful: bool) -> KeyAction {
         if let Some(prc) = self.get_selected_process() {
             let pid = prc.pid;
-            return match self
-                .ops_sender
-                .send(Operations::KillProcess { pid, graceful })
-            {
+            let name = prc.cmd.clone();
+            return match self.ops_sender.send(Operations::KillProcess {
+                pid,
+                graceful,
+                name,
+            }) {
                 Ok(_) => KeyAction::Consumed,
                 Err(_) => KeyAction::Event(ComponentEvent::ShowNotification(Notification::error(
                     "Failed to send kill request to process daemon",
@@ -161,7 +159,7 @@ impl ProcessesViewComponent {
         };
 
         self.search_bar.set_search_text(&search_string);
-        match self.search_for_processess(false) {
+        match self.search_for_processess() {
             Ok(()) => KeyAction::Consumed,
             Err(notification) => KeyAction::Event(ComponentEvent::ShowNotification(notification)),
         }
@@ -195,37 +193,14 @@ impl ProcessesViewComponent {
     }
 }
 
-fn update_refresh_notification_on_search_request(
-    show_refresh_result_notification: &mut bool,
-    triggered_by_refresh: bool,
-) {
-    if !triggered_by_refresh {
-        *show_refresh_result_notification = false;
-    }
-}
+fn process_result_message(prefix: &str, process: &KilledProcess) -> String {
+    let name = if process.name.is_empty() {
+        "unknown"
+    } else {
+        process.name.as_str()
+    };
 
-fn notification_for_operation_result(
-    result: &OperationResult,
-    show_refresh_result_notification: &mut bool,
-) -> Option<Notification> {
-    match result {
-        OperationResult::ProcessKilled(_) => Some(Notification::success("Process killed")),
-        OperationResult::ProcessKillFailed => Some(Notification::error(
-            "Failed to kill process. Check permissions",
-        )),
-        OperationResult::Error(error) => {
-            *show_refresh_result_notification = false;
-            Some(Notification::error(error.clone()))
-        }
-        OperationResult::SearchCompleted(_) => {
-            if *show_refresh_result_notification {
-                *show_refresh_result_notification = false;
-                Some(Notification::info("Process list refreshed"))
-            } else {
-                None
-            }
-        }
-    }
+    format!("{prefix} - {name} : PID {}", process.pid)
 }
 
 impl Component for ProcessesViewComponent {
@@ -235,34 +210,21 @@ impl Component for ProcessesViewComponent {
                 OperationResult::SearchCompleted(results) => {
                     self.search_results = results;
                     self.update_process_table_state();
-                    return notification_for_operation_result(
-                        &OperationResult::SearchCompleted(ProcessSearchResults::empty()),
-                        &mut self.show_refresh_result_notification,
-                    )
-                    .map(ComponentEvent::ShowNotification);
                 }
-                OperationResult::ProcessKilled(results) => {
+                OperationResult::ProcessKilled { results, process } => {
                     self.search_results = results;
                     self.update_process_table_state();
-                    return notification_for_operation_result(
-                        &OperationResult::ProcessKilled(ProcessSearchResults::empty()),
-                        &mut self.show_refresh_result_notification,
-                    )
-                    .map(ComponentEvent::ShowNotification);
+                    return Some(ComponentEvent::ShowNotification(Notification::success(
+                        process_result_message("Process killed", &process),
+                    )));
                 }
-                OperationResult::ProcessKillFailed => {
-                    return notification_for_operation_result(
-                        &OperationResult::ProcessKillFailed,
-                        &mut self.show_refresh_result_notification,
-                    )
-                    .map(ComponentEvent::ShowNotification);
+                OperationResult::ProcessKillFailed(process) => {
+                    return Some(ComponentEvent::ShowNotification(Notification::error(
+                        process_result_message("Failed to kill process", &process),
+                    )));
                 }
                 OperationResult::Error(err) => {
-                    return notification_for_operation_result(
-                        &OperationResult::Error(err),
-                        &mut self.show_refresh_result_notification,
-                    )
-                    .map(ComponentEvent::ShowNotification);
+                    return Some(ComponentEvent::ShowNotification(Notification::error(err)));
                 }
             }
         }
@@ -297,11 +259,9 @@ impl Component for ProcessesViewComponent {
                 return self.kill_selected_process(false);
             }
             AppAction::RefreshProcessList => {
-                self.show_refresh_result_notification = true;
-                return match self.search_for_processess(true) {
+                return match self.search_for_processess() {
                     Ok(()) => KeyAction::Consumed,
                     Err(notification) => {
-                        self.show_refresh_result_notification = false;
                         KeyAction::Event(ComponentEvent::ShowNotification(notification))
                     }
                 };
@@ -347,7 +307,7 @@ impl Component for ProcessesViewComponent {
             }
             AppAction::DeleteChar => {
                 self.search_bar.delete_char();
-                return match self.search_for_processess(false) {
+                return match self.search_for_processess() {
                     Ok(()) => KeyAction::Consumed,
                     Err(notification) => {
                         KeyAction::Event(ComponentEvent::ShowNotification(notification))
@@ -357,7 +317,7 @@ impl Component for ProcessesViewComponent {
             AppAction::DeleteNextChar => {
                 self.search_bar.delete_next_char();
 
-                return match self.search_for_processess(false) {
+                return match self.search_for_processess() {
                     Ok(()) => KeyAction::Consumed,
                     Err(notification) => {
                         KeyAction::Event(ComponentEvent::ShowNotification(notification))
@@ -366,7 +326,7 @@ impl Component for ProcessesViewComponent {
             }
             AppAction::DeleteWord => {
                 self.search_bar.delete_word();
-                return match self.search_for_processess(false) {
+                return match self.search_for_processess() {
                     Ok(()) => KeyAction::Consumed,
                     Err(notification) => {
                         KeyAction::Event(ComponentEvent::ShowNotification(notification))
@@ -375,7 +335,7 @@ impl Component for ProcessesViewComponent {
             }
             AppAction::DeleteToStart => {
                 self.search_bar.delete_to_start();
-                return match self.search_for_processess(false) {
+                return match self.search_for_processess() {
                     Ok(()) => KeyAction::Consumed,
                     Err(notification) => {
                         KeyAction::Event(ComponentEvent::ShowNotification(notification))
@@ -384,7 +344,7 @@ impl Component for ProcessesViewComponent {
             }
             AppAction::DeleteToEnd => {
                 self.search_bar.delete_to_end();
-                return match self.search_for_processess(false) {
+                return match self.search_for_processess() {
                     Ok(()) => KeyAction::Consumed,
                     Err(notification) => {
                         KeyAction::Event(ComponentEvent::ShowNotification(notification))
@@ -393,7 +353,7 @@ impl Component for ProcessesViewComponent {
             }
             AppAction::DeleteNextWord => {
                 self.search_bar.delete_next_word();
-                return match self.search_for_processess(false) {
+                return match self.search_for_processess() {
                     Ok(()) => KeyAction::Consumed,
                     Err(notification) => {
                         KeyAction::Event(ComponentEvent::ShowNotification(notification))
@@ -403,7 +363,7 @@ impl Component for ProcessesViewComponent {
             AppAction::Unmapped => {
                 if let Char(c) = key.code {
                     self.search_bar.insert_char(c);
-                    return match self.search_for_processess(false) {
+                    return match self.search_for_processess() {
                         Ok(()) => KeyAction::Consumed,
                         Err(notification) => {
                             KeyAction::Event(ComponentEvent::ShowNotification(notification))
@@ -438,100 +398,46 @@ impl Drop for ProcessesViewComponent {
 
 #[cfg(test)]
 mod tests {
-    use crate::processes::{OperationResult, ProcessSearchResults};
-    use crate::tui::components::NotificationSeverity;
+    use crate::processes::KilledProcess;
 
-    use super::{notification_for_operation_result, update_refresh_notification_on_search_request};
-
-    #[test]
-    fn maps_process_kill_success_to_success_notification() {
-        let mut show_refresh_result_notification = false;
-        let notification = notification_for_operation_result(
-            &OperationResult::ProcessKilled(ProcessSearchResults::empty()),
-            &mut show_refresh_result_notification,
-        )
-        .unwrap();
-
-        assert_eq!(notification.severity, NotificationSeverity::Success);
-        assert_eq!(notification.message, "Process killed");
-    }
+    use super::process_result_message;
 
     #[test]
-    fn maps_process_kill_failure_to_error_notification() {
-        let mut show_refresh_result_notification = false;
-        let notification = notification_for_operation_result(
-            &OperationResult::ProcessKillFailed,
-            &mut show_refresh_result_notification,
-        )
-        .unwrap();
-
-        assert_eq!(notification.severity, NotificationSeverity::Error);
-        assert_eq!(
-            notification.message,
-            "Failed to kill process. Check permissions"
-        );
-    }
-
-    #[test]
-    fn maps_daemon_errors_to_error_notification() {
-        let mut show_refresh_result_notification = false;
-        let notification = notification_for_operation_result(
-            &OperationResult::Error("daemon failed".to_string()),
-            &mut show_refresh_result_notification,
-        )
-        .unwrap();
-
-        assert_eq!(notification.severity, NotificationSeverity::Error);
-        assert_eq!(notification.message, "daemon failed");
-    }
-
-    #[test]
-    fn clears_refresh_flag_after_daemon_error() {
-        let mut show_refresh_result_notification = true;
-
-        let notification = notification_for_operation_result(
-            &OperationResult::Error("daemon failed".to_string()),
-            &mut show_refresh_result_notification,
-        )
-        .unwrap();
-
-        assert_eq!(notification.severity, NotificationSeverity::Error);
-        assert!(!show_refresh_result_notification);
-    }
-
-    #[test]
-    fn does_not_emit_refresh_notification_after_error_then_next_search_completion() {
-        let mut show_refresh_result_notification = true;
-
-        notification_for_operation_result(
-            &OperationResult::Error("daemon failed".to_string()),
-            &mut show_refresh_result_notification,
+    fn builds_success_message_with_name_and_pid() {
+        let message = process_result_message(
+            "Process killed",
+            &KilledProcess {
+                pid: 4242,
+                name: "pik".to_string(),
+            },
         );
 
-        let notification = notification_for_operation_result(
-            &OperationResult::SearchCompleted(ProcessSearchResults::empty()),
-            &mut show_refresh_result_notification,
+        assert_eq!(message, "Process killed - pik : PID 4242");
+    }
+
+    #[test]
+    fn builds_failure_message_with_name_and_pid() {
+        let message = process_result_message(
+            "Failed to kill process",
+            &KilledProcess {
+                pid: 4242,
+                name: "pik".to_string(),
+            },
         );
 
-        assert!(notification.is_none());
-        assert!(!show_refresh_result_notification);
+        assert_eq!(message, "Failed to kill process - pik : PID 4242");
     }
 
     #[test]
-    fn non_refresh_search_clears_pending_refresh_notification() {
-        let mut show_refresh_result_notification = true;
+    fn falls_back_to_unknown_name_when_process_name_is_empty() {
+        let message = process_result_message(
+            "Process killed",
+            &KilledProcess {
+                pid: 4242,
+                name: String::new(),
+            },
+        );
 
-        update_refresh_notification_on_search_request(&mut show_refresh_result_notification, false);
-
-        assert!(!show_refresh_result_notification);
-    }
-
-    #[test]
-    fn refresh_search_keeps_pending_refresh_notification() {
-        let mut show_refresh_result_notification = true;
-
-        update_refresh_notification_on_search_request(&mut show_refresh_result_notification, true);
-
-        assert!(show_refresh_result_notification);
+        assert_eq!(message, "Process killed - unknown : PID 4242");
     }
 }

--- a/src/tui/components/processes_view.rs
+++ b/src/tui/components/processes_view.rs
@@ -13,7 +13,10 @@ use crate::tui::components::search_bar::CursorMove;
 use crate::{
     config::ui::UIConfig,
     processes::{IgnoreOptions, Process, ProcessSearchResults},
-    tui::{ProcessRelatedSearch, components::KeyAction},
+    tui::{
+        ProcessRelatedSearch,
+        components::{KeyAction, Notification},
+    },
 };
 
 use super::{
@@ -28,6 +31,7 @@ pub struct ProcessesViewComponent {
     process_table_component: ProcessTableComponent,
     process_details_component: ProcessDetailsComponent,
     search_bar: SearchBarComponent,
+    show_refresh_result_notification: bool,
 }
 
 //NOTE: this is wrapped in a Lazy Mutex because arboard's Clipboard may cause issues when you don't
@@ -63,6 +67,7 @@ impl ProcessesViewComponent {
                 &ui_config.search_bar,
                 ui_config.icons.get_icons().search_prompt.as_str(),
             ),
+            show_refresh_result_notification: false,
         };
         component.update_process_table_state();
         Ok(component)
@@ -103,12 +108,12 @@ impl ProcessesViewComponent {
             .update_process_table_state(number_of_items);
     }
 
-    fn search_for_processess(&mut self) -> KeyAction {
+    fn search_for_processess(&mut self) -> Result<(), Notification> {
         let search_text = self.search_bar.get_search_text().to_string();
         match self.ops_sender.send(Operations::Search(search_text)) {
-            Ok(_) => KeyAction::Event(ComponentEvent::ProcessListRefreshRequested),
-            Err(_) => KeyAction::Event(ComponentEvent::ErrorOccurred(
-                "Failed to send search request to process daemon".to_string(),
+            Ok(_) => Ok(()),
+            Err(_) => Err(Notification::error(
+                "Failed to send search request to process daemon",
             )),
         }
     }
@@ -120,13 +125,15 @@ impl ProcessesViewComponent {
                 .ops_sender
                 .send(Operations::KillProcess { pid, graceful })
             {
-                Ok(_) => KeyAction::Event(ComponentEvent::ProcessKillRequested),
-                Err(_) => KeyAction::Event(ComponentEvent::ErrorOccurred(
-                    "Failed to send kill request to process daemon".to_string(),
-                )),
+                Ok(_) => KeyAction::Consumed,
+                Err(_) => KeyAction::Event(ComponentEvent::ShowNotification(Notification::error(
+                    "Failed to send kill request to process daemon",
+                ))),
             };
         }
-        KeyAction::Event(ComponentEvent::NoProcessToKill)
+        KeyAction::Event(ComponentEvent::ShowNotification(Notification::info(
+            "No process selected",
+        )))
     }
 
     fn enforce_search_by(&mut self, search_by: ProcessRelatedSearch) -> KeyAction {
@@ -148,7 +155,10 @@ impl ProcessesViewComponent {
         };
 
         self.search_bar.set_search_text(&search_string);
-        self.search_for_processess()
+        match self.search_for_processess() {
+            Ok(()) => KeyAction::Consumed,
+            Err(notification) => KeyAction::Event(ComponentEvent::ShowNotification(notification)),
+        }
     }
 
     fn copy_pid_to_clipboard(&mut self) -> KeyAction {
@@ -163,6 +173,17 @@ impl ProcessesViewComponent {
     }
 }
 
+fn notification_for_operation_result(result: &OperationResult) -> Option<Notification> {
+    match result {
+        OperationResult::ProcessKilled(_) => Some(Notification::success("Process killed")),
+        OperationResult::ProcessKillFailed => Some(Notification::error(
+            "Failed to kill process. Check permissions",
+        )),
+        OperationResult::Error(error) => Some(Notification::error(error.clone())),
+        OperationResult::SearchCompleted(_) => None,
+    }
+}
+
 impl Component for ProcessesViewComponent {
     fn update_state(&mut self) -> Option<ComponentEvent> {
         if let Ok(ops_result) = self.results_receiver.try_recv() {
@@ -170,18 +191,28 @@ impl Component for ProcessesViewComponent {
                 OperationResult::SearchCompleted(results) => {
                     self.search_results = results;
                     self.update_process_table_state();
-                    return Some(ComponentEvent::ProcessListRefreshed);
+                    if self.show_refresh_result_notification {
+                        self.show_refresh_result_notification = false;
+                        return Some(ComponentEvent::ShowNotification(Notification::info(
+                            "Process list refreshed",
+                        )));
+                    }
                 }
                 OperationResult::ProcessKilled(results) => {
                     self.search_results = results;
                     self.update_process_table_state();
-                    return Some(ComponentEvent::ProcessKilled);
+                    return notification_for_operation_result(&OperationResult::ProcessKilled(
+                        ProcessSearchResults::empty(),
+                    ))
+                    .map(ComponentEvent::ShowNotification);
                 }
                 OperationResult::ProcessKillFailed => {
-                    return Some(ComponentEvent::ProcessKillFailed);
+                    return notification_for_operation_result(&OperationResult::ProcessKillFailed)
+                        .map(ComponentEvent::ShowNotification);
                 }
                 OperationResult::Error(err) => {
-                    eprintln!("Error in process daemon: {err}");
+                    return notification_for_operation_result(&OperationResult::Error(err))
+                        .map(ComponentEvent::ShowNotification);
                 }
             }
         }
@@ -216,7 +247,14 @@ impl Component for ProcessesViewComponent {
                 return self.kill_selected_process(false);
             }
             AppAction::RefreshProcessList => {
-                return self.search_for_processess();
+                self.show_refresh_result_notification = true;
+                return match self.search_for_processess() {
+                    Ok(()) => KeyAction::Consumed,
+                    Err(notification) => {
+                        self.show_refresh_result_notification = false;
+                        KeyAction::Event(ComponentEvent::ShowNotification(notification))
+                    }
+                };
             }
             AppAction::CopyProcessPid => {
                 return self.copy_pid_to_clipboard();
@@ -259,33 +297,68 @@ impl Component for ProcessesViewComponent {
             }
             AppAction::DeleteChar => {
                 self.search_bar.delete_char();
-                return self.search_for_processess();
+                return match self.search_for_processess() {
+                    Ok(()) => KeyAction::Consumed,
+                    Err(notification) => {
+                        KeyAction::Event(ComponentEvent::ShowNotification(notification))
+                    }
+                };
             }
             AppAction::DeleteNextChar => {
                 self.search_bar.delete_next_char();
 
-                return self.search_for_processess();
+                return match self.search_for_processess() {
+                    Ok(()) => KeyAction::Consumed,
+                    Err(notification) => {
+                        KeyAction::Event(ComponentEvent::ShowNotification(notification))
+                    }
+                };
             }
             AppAction::DeleteWord => {
                 self.search_bar.delete_word();
-                return self.search_for_processess();
+                return match self.search_for_processess() {
+                    Ok(()) => KeyAction::Consumed,
+                    Err(notification) => {
+                        KeyAction::Event(ComponentEvent::ShowNotification(notification))
+                    }
+                };
             }
             AppAction::DeleteToStart => {
                 self.search_bar.delete_to_start();
-                return self.search_for_processess();
+                return match self.search_for_processess() {
+                    Ok(()) => KeyAction::Consumed,
+                    Err(notification) => {
+                        KeyAction::Event(ComponentEvent::ShowNotification(notification))
+                    }
+                };
             }
             AppAction::DeleteToEnd => {
                 self.search_bar.delete_to_end();
-                return self.search_for_processess();
+                return match self.search_for_processess() {
+                    Ok(()) => KeyAction::Consumed,
+                    Err(notification) => {
+                        KeyAction::Event(ComponentEvent::ShowNotification(notification))
+                    }
+                };
             }
             AppAction::DeleteNextWord => {
                 self.search_bar.delete_next_word();
-                return self.search_for_processess();
+                return match self.search_for_processess() {
+                    Ok(()) => KeyAction::Consumed,
+                    Err(notification) => {
+                        KeyAction::Event(ComponentEvent::ShowNotification(notification))
+                    }
+                };
             }
             AppAction::Unmapped => {
                 if let Char(c) = key.code {
                     self.search_bar.insert_char(c);
-                    return self.search_for_processess();
+                    return match self.search_for_processess() {
+                        Ok(()) => KeyAction::Consumed,
+                        Err(notification) => {
+                            KeyAction::Event(ComponentEvent::ShowNotification(notification))
+                        }
+                    };
                 }
             }
             _ => {
@@ -304,6 +377,47 @@ impl Component for ProcessesViewComponent {
             .render(frame, layout, &self.search_results);
         self.process_details_component
             .render(frame, layout, selected_process);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::processes::{OperationResult, ProcessSearchResults};
+    use crate::tui::components::NotificationSeverity;
+
+    use super::notification_for_operation_result;
+
+    #[test]
+    fn maps_process_kill_success_to_success_notification() {
+        let notification = notification_for_operation_result(&OperationResult::ProcessKilled(
+            ProcessSearchResults::empty(),
+        ))
+        .unwrap();
+
+        assert_eq!(notification.severity, NotificationSeverity::Success);
+        assert_eq!(notification.message, "Process killed");
+    }
+
+    #[test]
+    fn maps_process_kill_failure_to_error_notification() {
+        let notification =
+            notification_for_operation_result(&OperationResult::ProcessKillFailed).unwrap();
+
+        assert_eq!(notification.severity, NotificationSeverity::Error);
+        assert_eq!(
+            notification.message,
+            "Failed to kill process. Check permissions"
+        );
+    }
+
+    #[test]
+    fn maps_daemon_errors_to_error_notification() {
+        let notification =
+            notification_for_operation_result(&OperationResult::Error("daemon failed".to_string()))
+                .unwrap();
+
+        assert_eq!(notification.severity, NotificationSeverity::Error);
+        assert_eq!(notification.message, "daemon failed");
     }
 }
 

--- a/src/tui/components/processes_view.rs
+++ b/src/tui/components/processes_view.rs
@@ -34,12 +34,14 @@ pub struct ProcessesViewComponent {
     show_refresh_result_notification: bool,
 }
 
-//NOTE: this is wrapped in a Lazy Mutex because arboard's Clipboard may cause issues when you don't
-//have any clipboard manager installed, and it needs to be initialized only once.
-//FIXME: instead of failing we should send error massage to user
-static CLIPBOARD: std::sync::LazyLock<Mutex<Clipboard>> = std::sync::LazyLock::new(|| {
-    Mutex::new(Clipboard::new().expect("Failed to create clipboard instance"))
-});
+// NOTE: clipboard access is initialized lazily because some systems do not provide a clipboard
+// backend at all. Surface those failures to the user instead of crashing the TUI.
+static CLIPBOARD: std::sync::LazyLock<Result<Mutex<Clipboard>, String>> =
+    std::sync::LazyLock::new(|| {
+        Clipboard::new()
+            .map(Mutex::new)
+            .map_err(|err| format!("Clipboard is unavailable: {err}"))
+    });
 
 impl ProcessesViewComponent {
     pub fn new(
@@ -163,24 +165,53 @@ impl ProcessesViewComponent {
 
     fn copy_pid_to_clipboard(&mut self) -> KeyAction {
         if let Some(prc) = self.get_selected_process() {
-            CLIPBOARD
-                .lock()
-                .expect("Failed to lock clipboard")
-                .set_text(format!("{}", prc.pid))
-                .expect("Failed to copy pid");
+            let clipboard = match CLIPBOARD.as_ref() {
+                Ok(clipboard) => clipboard,
+                Err(err) => {
+                    return KeyAction::Event(ComponentEvent::ShowNotification(
+                        Notification::error(err.clone()),
+                    ));
+                }
+            };
+            let mut clipboard = match clipboard.lock() {
+                Ok(clipboard) => clipboard,
+                Err(_) => {
+                    return KeyAction::Event(ComponentEvent::ShowNotification(
+                        Notification::error("Clipboard is currently unavailable"),
+                    ));
+                }
+            };
+            if let Err(err) = clipboard.set_text(format!("{}", prc.pid)) {
+                return KeyAction::Event(ComponentEvent::ShowNotification(Notification::error(
+                    format!("Failed to copy PID to clipboard: {err}"),
+                )));
+            }
         }
         KeyAction::Consumed
     }
 }
 
-fn notification_for_operation_result(result: &OperationResult) -> Option<Notification> {
+fn notification_for_operation_result(
+    result: &OperationResult,
+    show_refresh_result_notification: &mut bool,
+) -> Option<Notification> {
     match result {
         OperationResult::ProcessKilled(_) => Some(Notification::success("Process killed")),
         OperationResult::ProcessKillFailed => Some(Notification::error(
             "Failed to kill process. Check permissions",
         )),
-        OperationResult::Error(error) => Some(Notification::error(error.clone())),
-        OperationResult::SearchCompleted(_) => None,
+        OperationResult::Error(error) => {
+            *show_refresh_result_notification = false;
+            Some(Notification::error(error.clone()))
+        }
+        OperationResult::SearchCompleted(_) => {
+            if *show_refresh_result_notification {
+                *show_refresh_result_notification = false;
+                Some(Notification::info("Process list refreshed"))
+            } else {
+                None
+            }
+        }
     }
 }
 
@@ -191,28 +222,34 @@ impl Component for ProcessesViewComponent {
                 OperationResult::SearchCompleted(results) => {
                     self.search_results = results;
                     self.update_process_table_state();
-                    if self.show_refresh_result_notification {
-                        self.show_refresh_result_notification = false;
-                        return Some(ComponentEvent::ShowNotification(Notification::info(
-                            "Process list refreshed",
-                        )));
-                    }
+                    return notification_for_operation_result(
+                        &OperationResult::SearchCompleted(ProcessSearchResults::empty()),
+                        &mut self.show_refresh_result_notification,
+                    )
+                    .map(ComponentEvent::ShowNotification);
                 }
                 OperationResult::ProcessKilled(results) => {
                     self.search_results = results;
                     self.update_process_table_state();
-                    return notification_for_operation_result(&OperationResult::ProcessKilled(
-                        ProcessSearchResults::empty(),
-                    ))
+                    return notification_for_operation_result(
+                        &OperationResult::ProcessKilled(ProcessSearchResults::empty()),
+                        &mut self.show_refresh_result_notification,
+                    )
                     .map(ComponentEvent::ShowNotification);
                 }
                 OperationResult::ProcessKillFailed => {
-                    return notification_for_operation_result(&OperationResult::ProcessKillFailed)
-                        .map(ComponentEvent::ShowNotification);
+                    return notification_for_operation_result(
+                        &OperationResult::ProcessKillFailed,
+                        &mut self.show_refresh_result_notification,
+                    )
+                    .map(ComponentEvent::ShowNotification);
                 }
                 OperationResult::Error(err) => {
-                    return notification_for_operation_result(&OperationResult::Error(err))
-                        .map(ComponentEvent::ShowNotification);
+                    return notification_for_operation_result(
+                        &OperationResult::Error(err),
+                        &mut self.show_refresh_result_notification,
+                    )
+                    .map(ComponentEvent::ShowNotification);
                 }
             }
         }
@@ -389,9 +426,11 @@ mod tests {
 
     #[test]
     fn maps_process_kill_success_to_success_notification() {
-        let notification = notification_for_operation_result(&OperationResult::ProcessKilled(
-            ProcessSearchResults::empty(),
-        ))
+        let mut show_refresh_result_notification = false;
+        let notification = notification_for_operation_result(
+            &OperationResult::ProcessKilled(ProcessSearchResults::empty()),
+            &mut show_refresh_result_notification,
+        )
         .unwrap();
 
         assert_eq!(notification.severity, NotificationSeverity::Success);
@@ -400,8 +439,12 @@ mod tests {
 
     #[test]
     fn maps_process_kill_failure_to_error_notification() {
-        let notification =
-            notification_for_operation_result(&OperationResult::ProcessKillFailed).unwrap();
+        let mut show_refresh_result_notification = false;
+        let notification = notification_for_operation_result(
+            &OperationResult::ProcessKillFailed,
+            &mut show_refresh_result_notification,
+        )
+        .unwrap();
 
         assert_eq!(notification.severity, NotificationSeverity::Error);
         assert_eq!(
@@ -412,12 +455,47 @@ mod tests {
 
     #[test]
     fn maps_daemon_errors_to_error_notification() {
-        let notification =
-            notification_for_operation_result(&OperationResult::Error("daemon failed".to_string()))
-                .unwrap();
+        let mut show_refresh_result_notification = false;
+        let notification = notification_for_operation_result(
+            &OperationResult::Error("daemon failed".to_string()),
+            &mut show_refresh_result_notification,
+        )
+        .unwrap();
 
         assert_eq!(notification.severity, NotificationSeverity::Error);
         assert_eq!(notification.message, "daemon failed");
+    }
+
+    #[test]
+    fn clears_refresh_flag_after_daemon_error() {
+        let mut show_refresh_result_notification = true;
+
+        let notification = notification_for_operation_result(
+            &OperationResult::Error("daemon failed".to_string()),
+            &mut show_refresh_result_notification,
+        )
+        .unwrap();
+
+        assert_eq!(notification.severity, NotificationSeverity::Error);
+        assert!(!show_refresh_result_notification);
+    }
+
+    #[test]
+    fn does_not_emit_refresh_notification_after_error_then_next_search_completion() {
+        let mut show_refresh_result_notification = true;
+
+        notification_for_operation_result(
+            &OperationResult::Error("daemon failed".to_string()),
+            &mut show_refresh_result_notification,
+        );
+
+        let notification = notification_for_operation_result(
+            &OperationResult::SearchCompleted(ProcessSearchResults::empty()),
+            &mut show_refresh_result_notification,
+        );
+
+        assert!(notification.is_none());
+        assert!(!show_refresh_result_notification);
     }
 }
 

--- a/src/tui/components/processes_view.rs
+++ b/src/tui/components/processes_view.rs
@@ -110,7 +110,11 @@ impl ProcessesViewComponent {
             .update_process_table_state(number_of_items);
     }
 
-    fn search_for_processess(&mut self) -> Result<(), Notification> {
+    fn search_for_processess(&mut self, triggered_by_refresh: bool) -> Result<(), Notification> {
+        update_refresh_notification_on_search_request(
+            &mut self.show_refresh_result_notification,
+            triggered_by_refresh,
+        );
         let search_text = self.search_bar.get_search_text().to_string();
         match self.ops_sender.send(Operations::Search(search_text)) {
             Ok(_) => Ok(()),
@@ -157,7 +161,7 @@ impl ProcessesViewComponent {
         };
 
         self.search_bar.set_search_text(&search_string);
-        match self.search_for_processess() {
+        match self.search_for_processess(false) {
             Ok(()) => KeyAction::Consumed,
             Err(notification) => KeyAction::Event(ComponentEvent::ShowNotification(notification)),
         }
@@ -188,6 +192,15 @@ impl ProcessesViewComponent {
             }
         }
         KeyAction::Consumed
+    }
+}
+
+fn update_refresh_notification_on_search_request(
+    show_refresh_result_notification: &mut bool,
+    triggered_by_refresh: bool,
+) {
+    if !triggered_by_refresh {
+        *show_refresh_result_notification = false;
     }
 }
 
@@ -285,7 +298,7 @@ impl Component for ProcessesViewComponent {
             }
             AppAction::RefreshProcessList => {
                 self.show_refresh_result_notification = true;
-                return match self.search_for_processess() {
+                return match self.search_for_processess(true) {
                     Ok(()) => KeyAction::Consumed,
                     Err(notification) => {
                         self.show_refresh_result_notification = false;
@@ -334,7 +347,7 @@ impl Component for ProcessesViewComponent {
             }
             AppAction::DeleteChar => {
                 self.search_bar.delete_char();
-                return match self.search_for_processess() {
+                return match self.search_for_processess(false) {
                     Ok(()) => KeyAction::Consumed,
                     Err(notification) => {
                         KeyAction::Event(ComponentEvent::ShowNotification(notification))
@@ -344,7 +357,7 @@ impl Component for ProcessesViewComponent {
             AppAction::DeleteNextChar => {
                 self.search_bar.delete_next_char();
 
-                return match self.search_for_processess() {
+                return match self.search_for_processess(false) {
                     Ok(()) => KeyAction::Consumed,
                     Err(notification) => {
                         KeyAction::Event(ComponentEvent::ShowNotification(notification))
@@ -353,7 +366,7 @@ impl Component for ProcessesViewComponent {
             }
             AppAction::DeleteWord => {
                 self.search_bar.delete_word();
-                return match self.search_for_processess() {
+                return match self.search_for_processess(false) {
                     Ok(()) => KeyAction::Consumed,
                     Err(notification) => {
                         KeyAction::Event(ComponentEvent::ShowNotification(notification))
@@ -362,7 +375,7 @@ impl Component for ProcessesViewComponent {
             }
             AppAction::DeleteToStart => {
                 self.search_bar.delete_to_start();
-                return match self.search_for_processess() {
+                return match self.search_for_processess(false) {
                     Ok(()) => KeyAction::Consumed,
                     Err(notification) => {
                         KeyAction::Event(ComponentEvent::ShowNotification(notification))
@@ -371,7 +384,7 @@ impl Component for ProcessesViewComponent {
             }
             AppAction::DeleteToEnd => {
                 self.search_bar.delete_to_end();
-                return match self.search_for_processess() {
+                return match self.search_for_processess(false) {
                     Ok(()) => KeyAction::Consumed,
                     Err(notification) => {
                         KeyAction::Event(ComponentEvent::ShowNotification(notification))
@@ -380,7 +393,7 @@ impl Component for ProcessesViewComponent {
             }
             AppAction::DeleteNextWord => {
                 self.search_bar.delete_next_word();
-                return match self.search_for_processess() {
+                return match self.search_for_processess(false) {
                     Ok(()) => KeyAction::Consumed,
                     Err(notification) => {
                         KeyAction::Event(ComponentEvent::ShowNotification(notification))
@@ -390,7 +403,7 @@ impl Component for ProcessesViewComponent {
             AppAction::Unmapped => {
                 if let Char(c) = key.code {
                     self.search_bar.insert_char(c);
-                    return match self.search_for_processess() {
+                    return match self.search_for_processess(false) {
                         Ok(()) => KeyAction::Consumed,
                         Err(notification) => {
                             KeyAction::Event(ComponentEvent::ShowNotification(notification))
@@ -417,12 +430,18 @@ impl Component for ProcessesViewComponent {
     }
 }
 
+impl Drop for ProcessesViewComponent {
+    fn drop(&mut self) {
+        self.ops_sender.send(Operations::Shutdown).ok();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::processes::{OperationResult, ProcessSearchResults};
     use crate::tui::components::NotificationSeverity;
 
-    use super::notification_for_operation_result;
+    use super::{notification_for_operation_result, update_refresh_notification_on_search_request};
 
     #[test]
     fn maps_process_kill_success_to_success_notification() {
@@ -497,10 +516,22 @@ mod tests {
         assert!(notification.is_none());
         assert!(!show_refresh_result_notification);
     }
-}
 
-impl Drop for ProcessesViewComponent {
-    fn drop(&mut self) {
-        self.ops_sender.send(Operations::Shutdown).ok();
+    #[test]
+    fn non_refresh_search_clears_pending_refresh_notification() {
+        let mut show_refresh_result_notification = true;
+
+        update_refresh_notification_on_search_request(&mut show_refresh_result_notification, false);
+
+        assert!(!show_refresh_result_notification);
+    }
+
+    #[test]
+    fn refresh_search_keeps_pending_refresh_notification() {
+        let mut show_refresh_result_notification = true;
+
+        update_refresh_notification_on_search_request(&mut show_refresh_result_notification, true);
+
+        assert!(show_refresh_result_notification);
     }
 }

--- a/tests/config_merge.rs
+++ b/tests/config_merge.rs
@@ -44,7 +44,7 @@ fn inline_tables_are_merged_recursively() {
         [ui.popups.border]
         style = { bg = "#4c1d95" }
 
-        [ui.notifications]
+        [ui.notifications.theme]
         success = { bg = "#14532d" }
         "##,
     )
@@ -64,7 +64,7 @@ fn inline_tables_are_merged_recursively() {
             .bg(tailwind::VIOLET.c900)
     );
     assert_eq!(
-        config.ui.notifications.success,
+        config.ui.notifications.theme.success,
         Style::new()
             .fg(tailwind::GREEN.c400)
             .bg(Color::Rgb(20, 83, 45))

--- a/tests/config_merge.rs
+++ b/tests/config_merge.rs
@@ -1,7 +1,7 @@
 use pik::config::{default_config, parse_config};
 use ratatui::{
     layout::Margin,
-    style::{Modifier, Style, palette::tailwind},
+    style::{Color, Modifier, Style, palette::tailwind},
 };
 
 #[test]
@@ -43,6 +43,9 @@ fn inline_tables_are_merged_recursively() {
 
         [ui.popups.border]
         style = { bg = "#4c1d95" }
+
+        [ui.notifications]
+        success = { bg = "#14532d" }
         "##,
     )
     .unwrap();
@@ -59,6 +62,12 @@ fn inline_tables_are_merged_recursively() {
         Style::new()
             .fg(tailwind::GREEN.c400)
             .bg(tailwind::VIOLET.c900)
+    );
+    assert_eq!(
+        config.ui.notifications.success,
+        Style::new()
+            .fg(tailwind::GREEN.c400)
+            .bg(Color::Rgb(20, 83, 45))
     );
 }
 


### PR DESCRIPTION
/closes #143 
/closes #179 

- Add a dedicated TUI notification overlay for `info`, `success`, and `error` messages, and moved user feedback out of the help footer.
- Surface process kill success/failure, daemon/search errors, explicit refresh completion all now go to notification TUI than relay on relying on footer text.
- Clipboard failures as notifications to the TUI instead of panicking
- Add configurable notification styling and timeout support through UIConfig, default_config.toml, and config merge coverage.
- Kept notifications intentionally lightweight: they replace each other, auto-dismiss after a timeout, 

Possible Issue 
- Long TUI notification messages are currently truncated (height 3).

<img width="1920" height="1080" alt="Screenshot from 2026-04-08 09-53-42" src="https://github.com/user-attachments/assets/921d813a-e4eb-4d3f-9546-b2ed323eadf8" />

